### PR TITLE
ci(renovate): disable kotlin updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,8 +10,8 @@
   "timezone": "CET",
   "packageRules": [
     {
-      "matchPackageNames": ["org.jetbrains.kotlin.android", "androidx.compose.compiler:compiler"],
-      "groupName": "Kotlin and Compose compiler"
+      "matchPackageNames": ["org.jetbrains.kotlin.android"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Another approach to resolving the Compose compiler's dependency on specific Kotlin versions. Since Kotlin update can't succeed without a Compose compiler update, I'm going to try disabling Kotlin updates and applying them manually on Compose compiler update PRs.